### PR TITLE
get Scrollview to be the right size for the first render 

### DIFF
--- a/src/KeyboardAccessoryView.tsx
+++ b/src/KeyboardAccessoryView.tsx
@@ -41,7 +41,7 @@ export const KeyboardAccessoryView = React.memo(
     style,
     useListenersOnAndroid,
   }: Props) => {
-    const { onLayout, size } = useComponentSize()
+    const { onLayout, size, preLayout } = useComponentSize()
     const { keyboardEndPositionY, keyboardHeight } = useKeyboardDimensions(
       useListenersOnAndroid
     )
@@ -88,7 +88,7 @@ export const KeyboardAccessoryView = React.memo(
                 deltaY
               ),
             },
-            styles.container,
+            preLayout ? {} : styles.container, // initial render, position is relative, so scrollable starts at right position on first render
             style,
           ]}
           testID='container'
@@ -105,6 +105,8 @@ export const KeyboardAccessoryView = React.memo(
                 marginRight: right,
               },
               contentContainerStyle,
+              // eslint-disable-next-line react-native/no-inline-styles
+              preLayout ? { flex: 0 } : {}, // initial render sets flex to 0, so flex-basis is auto & and its size is determined by children
             ]}
           >
             {children}

--- a/src/hooks/useComponentSize.tsx
+++ b/src/hooks/useComponentSize.tsx
@@ -10,11 +10,13 @@ import { LayoutChangeEvent } from 'react-native'
  */
 export const useComponentSize = () => {
   const [size, setSize] = React.useState({ height: 0, width: 0 })
+  const [preLayout, setPreLayout] = React.useState(true)
 
   const onLayout = React.useCallback((event: LayoutChangeEvent) => {
+    setPreLayout(false)
     const { height, width } = event.nativeEvent.layout
     setSize({ height, width })
   }, [])
 
-  return { onLayout, size }
+  return { onLayout, size, preLayout }
 }


### PR DESCRIPTION
Prior to layout measurement, the Scrollview overlaps with the accessory view. This causes a noticeable jump when navigating to this screen. I implemented a quick fix to remove this jump.